### PR TITLE
🐛 Use URL instead of regex for shadow-db name

### DIFF
--- a/packages/migrator/src/migrator.ts
+++ b/packages/migrator/src/migrator.ts
@@ -728,7 +728,11 @@ export class Migrator {
    */
   async useShadowClient<T>(cb: (client: Client) => Promise<T>) {
     const shadowDbName = `shadow_${Date.now()}_${randomInt(1_000_000)}`
-    const shadowConnectionString = this.client.connectionString().replace(/\w+$/, shadowDbName)
+
+    const shadowConnectionUrl = new URL(this.client.connectionString());
+    shadowConnectionUrl.pathname = shadowDbName;
+    const shadowConnectionString = shadowConnectionUrl.toString();
+
     const shadowClient = createClient(shadowConnectionString, this.client.options)
 
     try {


### PR DESCRIPTION
connectionString is a URL, so it should be treated as such. regex didn't
handle more complex cases (such as "-" in the name of database).

And while it is possible to tweak regex for greater compatibility, using
actual URL-object guarantees proper result in ALL cases.

#434
