### PR TITLE
Support any standard-schema in `sql.type`

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -52,8 +52,9 @@
     "ts-node": "^10.9.2",
     "tsup": "^8.0.1",
     "typescript-eslint": "^7.1.0",
+    "valibot": "1.1.0",
     "vitest": "^1.2.2",
-    "zod": "^3.22.4",
+    "zod": "3.25.0-beta.20250515T085033",
     "zod-validation-error": "^3.3.0"
   },
   "dependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -54,8 +54,7 @@
     "typescript-eslint": "^7.1.0",
     "valibot": "1.1.0",
     "vitest": "^1.2.2",
-    "zod": "3.25.0-beta.20250515T085033",
-    "zod-validation-error": "^3.3.0"
+    "zod": "^3.24.4"
   },
   "dependencies": {
     "pg": "^8.11.3",

--- a/packages/client/src/sql.ts
+++ b/packages/client/src/sql.ts
@@ -25,7 +25,7 @@ const sqlMethodHelpers: SQLMethodHelpers = {
   type: type => {
     if (!looksLikeStandardSchema(type)) {
       const typeName = (type as {})?.constructor?.name
-      const hint = typeName?.includes('Zod') ? ` Try upgrading zod` : ''
+      const hint = typeName?.includes('Zod') ? ` Try upgrading zod to v3.24.0 or greater` : ''
       throw new Error(`Invalid type parser. Must be a Standard Schema. Got ${typeName}.${hint}`, {
         cause: type,
       })

--- a/packages/client/src/standard-schema/contract.ts
+++ b/packages/client/src/standard-schema/contract.ts
@@ -1,0 +1,66 @@
+// from https://github.com/standard-schema/standard-schema
+
+/** The Standard Schema interface. */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly '~standard': StandardSchemaV1.Props<Input, Output>
+}
+
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1
+    /** The vendor name of the schema library. */
+    readonly vendor: string
+    /** Validates unknown input values. */
+    readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output
+    /** The non-existent issues. */
+    readonly issues?: undefined
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined
+  }
+
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey
+  }
+
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input
+    /** The output type of the schema. */
+    readonly output: Output
+  }
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<Schema['~standard']['types']>['input']
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<Schema['~standard']['types']>['output']
+}

--- a/packages/client/src/standard-schema/errors.ts
+++ b/packages/client/src/standard-schema/errors.ts
@@ -1,0 +1,56 @@
+import {StandardSchemaV1} from './contract'
+import {looksLikeStandardSchemaFailure} from './utils'
+
+export const prettifyStandardSchemaError = (error: unknown): string | null => {
+  if (!looksLikeStandardSchemaFailure(error)) return null
+
+  const issues = [...error.issues]
+    .map(issue => {
+      const path = issue.path || []
+      const primitivePathSegments = path.map(segment => {
+        if (typeof segment === 'string' || typeof segment === 'number' || typeof segment === 'symbol') return segment
+        return segment.key
+      })
+      const dotPath = toDotPath(primitivePathSegments)
+      return {
+        issue,
+        path,
+        primitivePathSegments,
+        dotPath,
+      }
+    })
+    .sort((a, b) => a.path.length - b.path.length)
+
+  const lines: string[] = []
+
+  for (const {issue, dotPath} of issues) {
+    let message = `✖ ${issue.message}`
+    if (dotPath) message += ` → at ${dotPath}`
+    lines.push(message)
+  }
+
+  return lines.join('\n')
+}
+
+export function toDotPath(path: (string | number | symbol)[]): string {
+  const segs: string[] = []
+  for (const seg of path) {
+    if (typeof seg === 'number') segs.push(`[${seg}]`)
+    else if (typeof seg === 'symbol') segs.push(`[${JSON.stringify(String(seg))}]`)
+    else if (/[^\w$]/.test(seg)) segs.push(`[${JSON.stringify(seg)}]`)
+    else {
+      if (segs.length) segs.push('.')
+      segs.push(seg)
+    }
+  }
+
+  return segs.join('')
+}
+
+export class StandardSchemaV1Error extends Error implements StandardSchemaV1.FailureResult {
+  issues: StandardSchemaV1.FailureResult['issues']
+  constructor(failure: StandardSchemaV1.FailureResult, options?: {cause?: Error}) {
+    super('Standard Schema error - details in `issues`.', options)
+    this.issues = failure.issues
+  }
+}

--- a/packages/client/src/standard-schema/utils.ts
+++ b/packages/client/src/standard-schema/utils.ts
@@ -1,0 +1,9 @@
+import {StandardSchemaV1} from './contract'
+
+export const looksLikeStandardSchemaFailure = (error: unknown): error is StandardSchemaV1.FailureResult => {
+  return !!error && typeof error === 'object' && 'issues' in error && Array.isArray(error.issues)
+}
+
+export const looksLikeStandardSchema = (thing: unknown): thing is StandardSchemaV1 => {
+  return !!thing && typeof thing === 'object' && '~standard' in thing && typeof thing['~standard'] === 'object'
+}

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import pgPromise from 'pg-promise'
+import {StandardSchemaV1} from './standard-schema/contract'
 
 export interface SQLQuery<Row = Record<string, unknown>, Values extends unknown[] = unknown[]> {
   token: 'sql'
@@ -190,17 +191,6 @@ export type TypeNameIdentifier =
   | 'uuid'
 /* eslint-enable @typescript-eslint/no-redundant-type-constituents */
 
-export type ZodesqueType<T> =
-  | ZodesqueTypeSafe<T>
-  | ZodesqueTypeAsyncSafe<T>
-  | ZodesqueTypeAsyncUnsafe<T>
-  | ZodesqueTypeUnsafe<T>
-export type ZodesqueTypeUnsafe<T> = {parse: (input: unknown) => T}
-export type ZodesqueTypeSafe<T> = {safeParse: (input: unknown) => ZodesqueResult<T>}
-export type ZodesqueTypeAsyncUnsafe<T> = {parseAsync: (input: unknown) => Promise<T>}
-export type ZodesqueTypeAsyncSafe<T> = {safeParseAsync: (input: unknown) => Promise<ZodesqueResult<T>>}
-export type ZodesqueResult<T> = {success: true; data: T} | {success: false; error: Error}
-
 export type SQLTagHelperParameters = {
   array: [values: readonly PrimitiveValueExpression[], memberType: MemberType]
   binary: [data: Buffer]
@@ -241,7 +231,7 @@ export type SQLTagFunction = <Row = Record<string, unknown>>(
 export type SQLMethodHelpers = {
   raw: <Row>(query: string, values?: unknown[]) => SQLQuery<Row, unknown[]>
   type: <Row>(
-    parser: ZodesqueType<Row>,
+    parser: StandardSchemaV1<any, Row>,
   ) => <Parameters extends SQLParameter[] = SQLParameter[]>(
     strings: TemplateStringsArray,
     ...parameters: Parameters

--- a/packages/client/test/api-usage.test.ts
+++ b/packages/client/test/api-usage.test.ts
@@ -2,8 +2,7 @@
 import * as v from 'valibot'
 import {beforeAll, beforeEach, expect, expectTypeOf, test, vi} from 'vitest'
 import {z} from 'zod'
-import {fromError, isZodErrorLike} from 'zod-validation-error'
-import {createClient, createSqlTag, QueryError, sql} from '../src'
+import {createClient, createSqlTag, sql} from '../src'
 import {printErrorCompact as printError} from './snapshots'
 
 expect.addSnapshotSerializer({
@@ -417,20 +416,6 @@ test('sql.type with custom error message', async () => {
         ...client.options.pgpOptions?.connect,
         application_name: 'impatient',
       },
-    },
-    wrapQueryFn: queryFn => {
-      const parentWrapper = client.options.wrapQueryFn || (x => x)
-      return async (...args) => {
-        const parentQueryFn = parentWrapper(queryFn)
-        try {
-          return await parentQueryFn(...args)
-        } catch (e) {
-          if (e instanceof QueryError && isZodErrorLike(e.cause)) {
-            e.cause = fromError(e.cause)
-          }
-          throw e
-        }
-      }
     },
   })
   const StringId = z.object({id: z.string()})

--- a/packages/client/test/snapshots.ts
+++ b/packages/client/test/snapshots.ts
@@ -1,10 +1,5 @@
-import {isValidationErrorLike, fromError, isZodErrorLike} from 'zod-validation-error'
-
 export function printError(val: any): string {
   const message = val instanceof Error ? `[${val.constructor.name}]: ${val.message}` : undefined
-  if (message && isValidationErrorLike(val)) {
-    return message
-  }
   const props = JSON.stringify(
     val,
     function reviver(this: any, key, value: any) {
@@ -32,10 +27,7 @@ export function printErrorCompact(val: any): string {
   const lines: string[] = []
   let e = val as Error | undefined
   while (e) {
-    if (isValidationErrorLike(e)) {
-      return printError(e)
-    }
-    const message = isZodErrorLike(e) ? `${fromError(e).message} (**auto-formatted for snapshot**)` : e.message
+    const message = e.message
     lines.push(`${'  '.repeat(lines.length)}${lines.length ? 'Caused by: ' : ''}[${e.constructor.name}]: ${message}`)
     e = e.cause as Error | undefined
   }

--- a/packages/client/test/zod.test.ts
+++ b/packages/client/test/zod.test.ts
@@ -89,7 +89,7 @@ test('Refine schemas', async () => {
 
   await expect(getResult()).rejects.toMatchInlineSnapshot(`
     {
-      "message": "[select-zod_test_83bbed1]: Parsing rows failed: see cause for details",
+      "message": "[select-zod_test_83bbed1]: Parsing rows failed: ✖ id must be even → at id\\n✖ Required → at name",
       "query": {
         "name": "select-zod_test_83bbed1",
         "sql": "\\n      select * from zod_test\\n    ",
@@ -99,6 +99,13 @@ test('Refine schemas', async () => {
       "cause": {
         "issues": [
           {
+            "code": "custom",
+            "message": "id must be even",
+            "path": [
+              "id"
+            ]
+          },
+          {
             "code": "invalid_type",
             "expected": "string",
             "received": "undefined",
@@ -106,16 +113,8 @@ test('Refine schemas', async () => {
               "name"
             ],
             "message": "Required"
-          },
-          {
-            "code": "custom",
-            "message": "id must be even",
-            "path": [
-              "id"
-            ]
           }
-        ],
-        "name": "ZodError"
+        ]
       }
     }
   `)

--- a/packages/typegen/package.json
+++ b/packages/typegen/package.json
@@ -44,7 +44,7 @@
     "pgsql-ast-parser": "^11.1.0",
     "pluralize": "^8.0.0",
     "trpc-cli": "^0.6.0-15",
-    "zod": "^3.23.8"
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@types/glob": "7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,19 +370,19 @@ importers:
         version: https://codeload.github.com/mmkal/np/tar.gz/6a58244afa28fd7d3f8c4dc4b6457c22d74e82de(typescript@5.8.2)
       pg-mem:
         specifier: 3.0.2
-        version: 3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.25.0-beta.20250515T085033))
+        version: 3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.24.4))
       quicktype-core:
         specifier: ^23.0.81
         version: 23.0.81(encoding@0.1.13)
       slonik:
         specifier: ^37.2.0
-        version: 37.2.0(zod@3.25.0-beta.20250515T085033)
+        version: 37.2.0(zod@3.24.4)
       slonik23:
         specifier: npm:slonik@^23.0.0
         version: slonik@23.9.0
       slonik37:
         specifier: npm:slonik@^37.0.0
-        version: slonik@37.2.0(zod@3.25.0-beta.20250515T085033)
+        version: slonik@37.2.0(zod@3.24.4)
       sql-formatter:
         specifier: ^15.2.0
         version: 15.2.0
@@ -405,11 +405,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2(@types/node@20.11.17)(sass@1.71.0)
       zod:
-        specifier: 3.25.0-beta.20250515T085033
-        version: 3.25.0-beta.20250515T085033
-      zod-validation-error:
-        specifier: ^3.3.0
-        version: 3.3.0(zod@3.25.0-beta.20250515T085033)
+        specifier: ^3.24.4
+        version: 3.24.4
 
   packages/formatter:
     dependencies:
@@ -8569,9 +8566,6 @@ packages:
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
-  zod@3.25.0-beta.20250515T085033:
-    resolution: {integrity: sha512-ze+cJjTCLg0n0gBForcQ7NFp8SALcTasTQqeUjARkjAmcsF0mDhVdtwHQX4NqeTSlSi+IvZVJ/fpR2yDGa48/Q==}
-
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -16146,7 +16140,7 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-mem@3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.25.0-beta.20250515T085033)):
+  pg-mem@3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.24.4)):
     dependencies:
       functional-red-black-tree: 1.0.1
       immutable: 4.3.5
@@ -16157,7 +16151,7 @@ snapshots:
       pgsql-ast-parser: 12.0.1
     optionalDependencies:
       pg-promise: 11.5.4
-      slonik: 37.2.0(zod@3.25.0-beta.20250515T085033)
+      slonik: 37.2.0(zod@3.24.4)
 
   pg-minify@1.6.3: {}
 
@@ -16968,7 +16962,7 @@ snapshots:
       recast: 0.23.6
       ts-morph: 18.0.0
       tsconfig-paths: 4.2.0
-      zod: 3.24.2
+      zod: 3.24.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17053,7 +17047,7 @@ snapshots:
     transitivePeerDependencies:
       - pg-native
 
-  slonik@37.2.0(zod@3.25.0-beta.20250515T085033):
+  slonik@37.2.0(zod@3.24.4):
     dependencies:
       '@types/pg': 8.11.0
       es6-error: 4.1.1
@@ -17068,7 +17062,7 @@ snapshots:
       roarr: 7.21.0
       safe-stable-stringify: 2.4.3
       serialize-error: 8.1.0
-      zod: 3.25.0-beta.20250515T085033
+      zod: 3.24.4
     transitivePeerDependencies:
       - pg-native
 
@@ -18513,10 +18507,6 @@ snapshots:
     dependencies:
       zod: 3.24.4
 
-  zod-validation-error@3.3.0(zod@3.25.0-beta.20250515T085033):
-    dependencies:
-      zod: 3.25.0-beta.20250515T085033
-
   zod@3.22.4: {}
 
   zod@3.23.8: {}
@@ -18524,7 +18514,5 @@ snapshots:
   zod@3.24.2: {}
 
   zod@3.24.4: {}
-
-  zod@3.25.0-beta.20250515T085033: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,8 +704,8 @@ importers:
         specifier: '*'
         version: 5.8.2
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.24.4
+        version: 3.24.4
     devDependencies:
       '@types/glob':
         specifier: 7.2.0
@@ -8566,6 +8566,9 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+
   zod@3.25.0-beta.20250515T085033:
     resolution: {integrity: sha512-ze+cJjTCLg0n0gBForcQ7NFp8SALcTasTQqeUjARkjAmcsF0mDhVdtwHQX4NqeTSlSi+IvZVJ/fpR2yDGa48/Q==}
 
@@ -10772,24 +10775,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.6.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)':
-    dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.1.0(eslint@8.57.0)(typescript@5.8.2)
-      '@typescript-eslint/scope-manager': 8.6.0
-      '@typescript-eslint/type-utils': 8.6.0(eslint@8.57.0)(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.6.0(eslint@8.57.0)(typescript@5.8.2)
-      '@typescript-eslint/visitor-keys': 8.6.0
-      eslint: 8.57.0
-      graphemer: 1.4.0
-      ignore: 5.3.1
-      natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.8.2)
-    optionalDependencies:
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.6.0(@typescript-eslint/parser@8.6.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
@@ -12764,7 +12749,7 @@ snapshots:
 
   eslint-config-xo-typescript@1.0.1(@typescript-eslint/eslint-plugin@8.6.0(@typescript-eslint/parser@8.6.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2))(@typescript-eslint/parser@8.6.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.6.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.6.0(@typescript-eslint/parser@8.6.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
       '@typescript-eslint/parser': 8.6.0(eslint@8.57.0)(typescript@5.8.2)
       eslint: 8.57.0
       typescript: 5.8.2
@@ -12975,7 +12960,7 @@ snapshots:
       '@rushstack/eslint-plugin-packlets': 0.8.1(eslint@8.57.0)(typescript@5.8.2)
       '@rushstack/eslint-plugin-security': 0.7.1(eslint@8.57.0)(typescript@5.8.2)
       '@types/eslint': 8.56.6
-      '@typescript-eslint/eslint-plugin': 8.6.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.6.0(@typescript-eslint/parser@8.6.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
       '@typescript-eslint/parser': 8.6.0(eslint@8.57.0)(typescript@5.8.2)
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-config-xo: 0.43.1(eslint@8.57.0)
@@ -13328,7 +13313,7 @@ snapshots:
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.8.2)
       eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.6.0(@typescript-eslint/parser@7.1.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.6.0(@typescript-eslint/parser@8.6.0(eslint@8.57.0)(typescript@5.8.2))(eslint@8.57.0)(typescript@5.8.2)
       vitest: 1.2.2(@types/node@20.11.17)(sass@1.71.0)
     transitivePeerDependencies:
       - supports-color
@@ -17511,9 +17496,9 @@ snapshots:
       '@types/omelette': 0.4.5
       commander: 13.1.0
       picocolors: 1.0.1
-      zod: 3.24.2
-      zod-to-json-schema: 3.23.0(zod@3.24.2)
-      zod-validation-error: 3.3.0(zod@3.24.2)
+      zod: 3.24.4
+      zod-to-json-schema: 3.23.0(zod@3.24.4)
+      zod-validation-error: 3.3.0(zod@3.24.4)
     optionalDependencies:
       '@inquirer/prompts': 5.0.4
     transitivePeerDependencies:
@@ -18516,17 +18501,17 @@ snapshots:
     dependencies:
       zod: 3.23.8
 
-  zod-to-json-schema@3.23.0(zod@3.24.2):
+  zod-to-json-schema@3.23.0(zod@3.24.4):
     dependencies:
-      zod: 3.24.2
+      zod: 3.24.4
 
   zod-validation-error@3.3.0(zod@3.23.8):
     dependencies:
       zod: 3.23.8
 
-  zod-validation-error@3.3.0(zod@3.24.2):
+  zod-validation-error@3.3.0(zod@3.24.4):
     dependencies:
-      zod: 3.24.2
+      zod: 3.24.4
 
   zod-validation-error@3.3.0(zod@3.25.0-beta.20250515T085033):
     dependencies:
@@ -18537,6 +18522,8 @@ snapshots:
   zod@3.23.8: {}
 
   zod@3.24.2: {}
+
+  zod@3.24.4: {}
 
   zod@3.25.0-beta.20250515T085033: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,19 +370,19 @@ importers:
         version: https://codeload.github.com/mmkal/np/tar.gz/6a58244afa28fd7d3f8c4dc4b6457c22d74e82de(typescript@5.8.2)
       pg-mem:
         specifier: 3.0.2
-        version: 3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.22.4))
+        version: 3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.25.0-beta.20250515T085033))
       quicktype-core:
         specifier: ^23.0.81
         version: 23.0.81(encoding@0.1.13)
       slonik:
         specifier: ^37.2.0
-        version: 37.2.0(zod@3.22.4)
+        version: 37.2.0(zod@3.25.0-beta.20250515T085033)
       slonik23:
         specifier: npm:slonik@^23.0.0
         version: slonik@23.9.0
       slonik37:
         specifier: npm:slonik@^37.0.0
-        version: slonik@37.2.0(zod@3.22.4)
+        version: slonik@37.2.0(zod@3.25.0-beta.20250515T085033)
       sql-formatter:
         specifier: ^15.2.0
         version: 15.2.0
@@ -398,15 +398,18 @@ importers:
       typescript-eslint:
         specifier: ^7.1.0
         version: 7.1.0(eslint@8.57.0)(typescript@5.8.2)
+      valibot:
+        specifier: 1.1.0
+        version: 1.1.0(typescript@5.8.2)
       vitest:
         specifier: ^1.2.2
         version: 1.2.2(@types/node@20.11.17)(sass@1.71.0)
       zod:
-        specifier: ^3.22.4
-        version: 3.22.4
+        specifier: 3.25.0-beta.20250515T085033
+        version: 3.25.0-beta.20250515T085033
       zod-validation-error:
         specifier: ^3.3.0
-        version: 3.3.0(zod@3.22.4)
+        version: 3.3.0(zod@3.25.0-beta.20250515T085033)
 
   packages/formatter:
     dependencies:
@@ -8305,6 +8308,14 @@ packages:
     resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
     engines: {node: '>=0.10.0'}
 
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -8554,6 +8565,9 @@ packages:
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
+  zod@3.25.0-beta.20250515T085033:
+    resolution: {integrity: sha512-ze+cJjTCLg0n0gBForcQ7NFp8SALcTasTQqeUjARkjAmcsF0mDhVdtwHQX4NqeTSlSi+IvZVJ/fpR2yDGa48/Q==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -15681,7 +15695,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.1.0
-      zod: 3.23.8
+      zod: 3.24.2
 
   nextra@2.13.4(next@14.2.4(@playwright/test@1.42.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -15713,7 +15727,7 @@ snapshots:
       title: 3.5.3
       unist-util-remove: 4.0.0
       unist-util-visit: 5.0.0
-      zod: 3.23.8
+      zod: 3.24.2
     transitivePeerDependencies:
       - supports-color
 
@@ -16147,7 +16161,7 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-mem@3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.22.4)):
+  pg-mem@3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.25.0-beta.20250515T085033)):
     dependencies:
       functional-red-black-tree: 1.0.1
       immutable: 4.3.5
@@ -16158,7 +16172,7 @@ snapshots:
       pgsql-ast-parser: 12.0.1
     optionalDependencies:
       pg-promise: 11.5.4
-      slonik: 37.2.0(zod@3.22.4)
+      slonik: 37.2.0(zod@3.25.0-beta.20250515T085033)
 
   pg-minify@1.6.3: {}
 
@@ -16969,7 +16983,7 @@ snapshots:
       recast: 0.23.6
       ts-morph: 18.0.0
       tsconfig-paths: 4.2.0
-      zod: 3.23.8
+      zod: 3.24.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17054,7 +17068,7 @@ snapshots:
     transitivePeerDependencies:
       - pg-native
 
-  slonik@37.2.0(zod@3.22.4):
+  slonik@37.2.0(zod@3.25.0-beta.20250515T085033):
     dependencies:
       '@types/pg': 8.11.0
       es6-error: 4.1.1
@@ -17069,7 +17083,7 @@ snapshots:
       roarr: 7.21.0
       safe-stable-stringify: 2.4.3
       serialize-error: 8.1.0
-      zod: 3.22.4
+      zod: 3.25.0-beta.20250515T085033
     transitivePeerDependencies:
       - pg-native
 
@@ -17987,6 +18001,10 @@ snapshots:
 
   vali-date@1.0.0: {}
 
+  valibot@1.1.0(typescript@5.8.2):
+    optionalDependencies:
+      typescript: 5.8.2
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -18502,10 +18520,6 @@ snapshots:
     dependencies:
       zod: 3.24.2
 
-  zod-validation-error@3.3.0(zod@3.22.4):
-    dependencies:
-      zod: 3.22.4
-
   zod-validation-error@3.3.0(zod@3.23.8):
     dependencies:
       zod: 3.23.8
@@ -18514,10 +18528,16 @@ snapshots:
     dependencies:
       zod: 3.24.2
 
+  zod-validation-error@3.3.0(zod@3.25.0-beta.20250515T085033):
+    dependencies:
+      zod: 3.25.0-beta.20250515T085033
+
   zod@3.22.4: {}
 
   zod@3.23.8: {}
 
   zod@3.24.2: {}
+
+  zod@3.25.0-beta.20250515T085033: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Simplifies code by removing `ZodEsque...` types etc. (more code is added, but it's just copy-paste from standard-schema).

This also copies zod's pretty error printer so we can pretty reliably get nice looking errors from pretty much any standard-schema library. (Or rather, my modification of zod's error printer): https://github.com/standard-schema/standard-schema/issues/84