### PR TITLE
await sql`select foo from bar`

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -88,7 +88,7 @@
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.22.4"
+    "zod": "^3.25.20"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -54,7 +54,7 @@
     "typescript-eslint": "^7.1.0",
     "valibot": "1.1.0",
     "vitest": "^1.2.2",
-    "zod": "^3.24.4"
+    "zod": "^3.25.20"
   },
   "dependencies": {
     "pg": "~8.14.1",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,6 +3,7 @@ export * from './client'
 export * from './errors'
 export * from './naming'
 export * from './sql'
+export * from './storage'
 export * from './type-parsers'
 export * from './types'
 // codegen:end

--- a/packages/client/src/sql.ts
+++ b/packages/client/src/sql.ts
@@ -10,10 +10,10 @@ import {
   SQLQuery,
   SQLTagHelpers,
   SQLParameter,
-  Client,
   AwaitSqlResultArray,
   Queryable,
   AwaitableSQLQuery,
+  SQLTag,
 } from './types'
 
 /** a monadish `.map` which allows for promises or regular values and becomes a promise-or-regular-value with the return type of the mapper */
@@ -288,12 +288,12 @@ export const sqlTagHelpers: SQLTagHelpers = {
 
 export const allSqlHelpers = {...sqlMethodHelpers, ...sqlTagHelpers}
 
-export const sql: SQLTagFunction & SQLTagHelpers & SQLMethodHelpers = Object.assign(sqlFn, allSqlHelpers)
+export const sql: SQLTag = Object.assign(sqlFn, allSqlHelpers)
 
 // export function createSqlTag<TypeAliases extends Record<string, StandardSchemaV1>>(params: {typeAliases: TypeAliases})
 export const createSqlTag = <TypeAliases extends Record<string, StandardSchemaV1>>(params: {
   typeAliases?: TypeAliases
-  client?: Client
+  client?: Queryable
 }) => {
   // eslint-disable-next-line func-name-matching, func-names, @typescript-eslint/no-shadow
   const fn = function sql(...args: Parameters<SQLTagFunction>) {

--- a/packages/client/src/sql.ts
+++ b/packages/client/src/sql.ts
@@ -3,13 +3,31 @@ import {QueryError} from './errors'
 import {nameQuery} from './naming'
 import {StandardSchemaV1} from './standard-schema/contract'
 import {looksLikeStandardSchema, looksLikeStandardSchemaFailure} from './standard-schema/utils'
-import {SQLTagFunction, SQLMethodHelpers, SQLQuery, SQLTagHelpers, SQLParameter} from './types'
+import {pgkitStorage} from './storage'
+import {
+  SQLTagFunction,
+  SQLMethodHelpers,
+  SQLQuery,
+  SQLTagHelpers,
+  SQLParameter,
+  Client,
+  AwaitSqlResultArray,
+  Queryable,
+} from './types'
 
+/** a monadish `.map` which allows for promises or regular values and becomes a promise-or-regular-value with the return type of the mapper */
 const maybeAsyncMap = <T, U>(thing: T | Promise<T>, map: (value: T) => U): U | Promise<U> => {
   if (typeof (thing as {then?: unknown})?.then === 'function') {
     return (thing as {then: (mapper: typeof map) => Promise<U>}).then(map)
   }
   return map(thing as T)
+}
+
+/**
+ * Template tag function. Walks through each string segment and parameter, and concatenates them into a valid SQL query.
+ */
+const sqlFn: SQLTagFunction = (strings, ...templateParameters) => {
+  return sqlFnInner({}, strings, ...templateParameters)
 }
 
 const sqlMethodHelpers: SQLMethodHelpers = {
@@ -22,7 +40,11 @@ const sqlMethodHelpers: SQLMethodHelpers = {
     segments: () => [query],
     templateArgs: () => [[query]],
   }),
-  type: type => {
+  type: typer(undefined, sqlFn),
+}
+
+function typer(client: Queryable | undefined, sqlFnImpl: typeof sqlFn): SQLMethodHelpers['type'] {
+  return <Row>(type: StandardSchemaV1<Row>) => {
     if (!looksLikeStandardSchema(type)) {
       const typeName = (type as {})?.constructor?.name
       const hint = typeName?.includes('Zod') ? ` Try upgrading zod to v3.24.0 or greater` : ''
@@ -31,61 +53,26 @@ const sqlMethodHelpers: SQLMethodHelpers = {
       })
     }
     const {validate} = type['~standard']
-    const parseAsync = (input: unknown) => {
+    const parseFn = (input: unknown) => {
       return maybeAsyncMap(validate(input), result => {
-        if (looksLikeStandardSchemaFailure(result)) {
-          throw result as {} as Error
-        }
+        if (looksLikeStandardSchemaFailure(result)) throw result as {} as Error
         return result.value
       })
     }
-    // type Result = typeof type extends ZodesqueType<infer R> ? R : never
-    // let parseAsync: (input: unknown) => Promise<Result>
-    // if ('parseAsync' in type) {
-    //   parseAsync = type.parseAsync
-    // } else if ('safeParseAsync' in type) {
-    //   parseAsync = async input => {
-    //     const parsed = await type.safeParseAsync(input)
-    //     if (!parsed.success) {
-    //       throw parsed.error
-    //     }
-    //     return parsed.data
-    //   }
-    // } else if ('parse' in type) {
-    //   parseAsync = async input => type.parse(input)
-    // } else if ('safeParse' in type) {
-    //   parseAsync = async input => {
-    //     const parsed = type.safeParse(input)
-    //     if (!parsed.success) {
-    //       throw parsed.error
-    //     }
-    //     return parsed.data
-    //   }
-    // } else {
-    //   const _: never = type
-    //   throw new Error('Invalid type parser. Must have parse, safeParse, parseAsync or safeParseAsync method', {
-    //     cause: type,
-    //   })
-    // }
-    return (strings, ...parameters) => ({
-      ...sqlFn(strings, ...(parameters as never)),
-      parse: parseAsync,
-    })
-  },
-}
-
-/**
- * Template tag function. Walks through each string segment and parameter, and concatenates them into a valid SQL query.
- */
-const sqlFn: SQLTagFunction = (strings, ...templateParameters) => {
-  return sqlFnInner({}, strings, ...templateParameters)
+    return (strings, ...parameters) => {
+      const {then, parse, ...rest} = sqlFnImpl(strings, ...parameters)
+      const baseQuery = {...rest, parse: parseFn}
+      // eslint-disable-next-line unicorn/no-thenable
+      return {...baseQuery, then: getThenFn({client, sqlQuery: baseQuery})}
+    }
+  }
 }
 
 const sqlFnInner = (
-  {priorValues = 0},
+  {priorValues = 0, client = undefined as Queryable | undefined, parse = (x => x) as SQLQuery<never>['parse']},
   strings: TemplateStringsArray,
   ...templateParameters: SQLParameter[]
-): SQLQuery<never> => {
+): SQLQuery<never> & {then: <U>(callback: (rows: Promise<AwaitSqlResultArray<never>>) => U) => Promise<U>} => {
   const segments: string[] = []
   const values: unknown[] = []
   const getValuePlaceholder = (inc = 0) => '$' + (values.length + priorValues + inc)
@@ -106,21 +93,8 @@ const sqlFnInner = (
 
     switch (param.token) {
       case 'array': {
-        if (Math.random()) {
-          values.push(param.args[0])
-          segments.push(getValuePlaceholder(), `::${param.args[1]}[]`)
-          break
-        }
-        // console.log('param', param)
-        segments.push(`array[`)
-        for (const [i, v] of param.args[0].entries()) {
-          if (i > 0) segments.push(', ')
-          values.push(v)
-          segments.push(`${getValuePlaceholder()}::${param.args[1]}`)
-        }
-        segments.push(']')
-        // values.push(param.args[0])
-        // segments.push(getValuePlaceholder())
+        values.push(param.args[0])
+        segments.push(getValuePlaceholder(), `::${param.args[1]}[]`)
         break
       }
       case 'binary':
@@ -213,14 +187,87 @@ const sqlFnInner = (
     }
   })
 
-  return {
-    parse: input => input as never,
+  const sqlQuery: SQLQuery<never> = {
+    parse,
     name: nameQuery(strings),
     sql: segments.join(''),
     token: 'sql',
     values,
     segments: () => segments,
     templateArgs: () => [strings, ...templateParameters],
+  }
+  return {
+    ...sqlQuery,
+    // eslint-disable-next-line unicorn/no-thenable
+    then: getThenFn({client, sqlQuery}),
+  }
+}
+
+function getThenFn<X>({client, sqlQuery}: {client: Queryable | undefined; sqlQuery: SQLQuery<X>}) {
+  return <U>(onSuccess: (rows: Promise<AwaitSqlResultArray<never>>) => U) => {
+    const getAwaitSqlResultArrayAsync = async (): Promise<AwaitSqlResultArray<never>> => {
+      const queryable = client || pgkitStorage.getStore()?.client
+      if (!queryable) {
+        const msg =
+          'No client provided to sql tag - either use `createSqlTag({client})` or provide it with `pgkitStorage.run({client}, () => ...)`'
+        throw new Error(msg)
+      }
+      return queryable.any(sqlQuery).then(rows => {
+        const errorParams: QueryError.Params = {query: sqlQuery, result: {rows}}
+        const getOne = () => {
+          if (rows.length !== 1) throw new QueryError(`Expected 1 row, got ${rows.length}`, errorParams)
+          return rows[0]
+        }
+        const getMany = () => {
+          if (rows.length === 0) throw new QueryError('Expected at least 1 row, got 0', errorParams)
+          return rows
+        }
+        Object.defineProperties(rows, {
+          one: {
+            get: getOne,
+          },
+          maybeOne: {
+            get() {
+              if (rows.length > 1) throw new QueryError(`Expected either 0 or 1 row, got ${rows.length}`, errorParams)
+              return rows.length === 1 ? rows[0] : null
+            },
+          },
+          oneFirst: {
+            get() {
+              return Object.values(getOne())[0]
+            },
+          },
+          maybeOneFirst: {
+            get() {
+              return rows.length === 1 ? Object.values(rows[0])[0] : null
+            },
+          },
+          many: {get: getMany},
+          manyFirst: {
+            get() {
+              return getMany().map(row => Object.values(row)[0])
+            },
+          },
+          noNulls: {
+            get() {
+              for (const [i, row] of rows.entries()) {
+                for (const [key, value] of Object.entries(row)) {
+                  if (value === null) throw new QueryError(`Null value at row ${i} column ${key}`, errorParams)
+                }
+              }
+              return rows
+            },
+          },
+        })
+        console.log({rows})
+        // eslint-disable-next-line promise/no-callback-in-promise
+        return rows as AwaitSqlResultArray<never>
+      })
+    }
+    return getAwaitSqlResultArrayAsync().then(
+      value => onSuccess(Promise.resolve(value)),
+      error => onSuccess(Promise.reject(error as Error)),
+    )
   }
 }
 
@@ -243,23 +290,37 @@ export const allSqlHelpers = {...sqlMethodHelpers, ...sqlTagHelpers}
 
 export const sql: SQLTagFunction & SQLTagHelpers & SQLMethodHelpers = Object.assign(sqlFn, allSqlHelpers)
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// export function createSqlTag<TypeAliases extends Record<string, StandardSchemaV1>>(params: {typeAliases: TypeAliases})
 export const createSqlTag = <TypeAliases extends Record<string, StandardSchemaV1>>(params: {
-  typeAliases: TypeAliases
+  typeAliases?: TypeAliases
+  client?: Client
 }) => {
   // eslint-disable-next-line func-name-matching, func-names, @typescript-eslint/no-shadow
   const fn = function sql(...args: Parameters<SQLTagFunction>) {
-    return sqlFn<{}>(...args)
-  } as SQLTagFunction
+    return sqlFnInner(params, ...args)
+  } as <Row = Record<string, unknown>>(
+    strings: TemplateStringsArray,
+    ...parameters: Row extends {'~parameters': SQLParameter[]} ? Row['~parameters'] : SQLParameter[]
+  ) => SQLQuery<Row extends {'~parameters': SQLParameter[]} ? Omit<Row, '~parameters'> : Row> & {
+    then: <U>(callback: (rows: AwaitSqlResultArray<Row>) => U) => Promise<U>
+  }
 
-  return Object.assign(fn, allSqlHelpers, {
-    typeAlias<K extends keyof TypeAliases>(name: K) {
-      const type = params.typeAliases[name]
-      type Result = typeof type extends StandardSchemaV1<any, infer R> ? R : never
-      return sql.type(type) as <Parameters extends SQLParameter[] = SQLParameter[]>(
-        strings: TemplateStringsArray,
-        ...parameters: Parameters
-      ) => SQLQuery<Result>
+  const {type, ...rest} = allSqlHelpers
+
+  return Object.assign(
+    fn,
+    rest,
+    {type: typer(params.client, (...args) => sqlFnInner(params, ...args))},
+    {
+      typeAlias<K extends keyof TypeAliases>(name: K) {
+        const type = params.typeAliases?.[name]
+        if (!type) throw new Error(`Type alias ${name as string} not found`)
+        type Result = typeof type extends StandardSchemaV1<any, infer R> ? R : never
+        return sql.type(type) as <Parameters extends SQLParameter[] = SQLParameter[]>(
+          strings: TemplateStringsArray,
+          ...parameters: Parameters
+        ) => SQLQuery<Result>
+      },
     },
-  })
+  )
 }

--- a/packages/client/src/storage.ts
+++ b/packages/client/src/storage.ts
@@ -1,0 +1,11 @@
+import {AsyncLocalStorage} from 'async_hooks'
+import {Queryable} from './types'
+
+/**
+ * @experimental
+ * A holder for the client and other pgkit config. Can be used to provide a client (or other queryable).
+ * Other libraries may be able to add more config here in the future.
+ *
+ * Note: this is only used for `` await sql`select 1` `` use-cases right now.
+ */
+export const pgkitStorage = new AsyncLocalStorage<{client?: Queryable}>()

--- a/packages/client/test/api-usage.test.ts
+++ b/packages/client/test/api-usage.test.ts
@@ -455,27 +455,27 @@ test('createSqlTag + sql.typeAlias', async () => {
 test('await sql - createSqlTag', async () => {
   const {sql} = client
 
-  const result = await sql<{a: number; b: number}>`select 1 as a, 2 as b`
+  const xx = await sql<{a: number; b: number}>`select 1 as a, 2 as b`
 
-  expect(result).toEqual([{a: 1, b: 2}])
-  expect(result.one).toEqual({a: 1, b: 2})
-  expect(result.oneFirst).toEqual(1)
-  expect(result.maybeOneFirst).toEqual(1)
-  expect(result.many).toEqual([{a: 1, b: 2}])
-  expect(result.manyFirst).toEqual([1])
-  expectTypeOf(result).toMatchTypeOf<{a: number; b: number}[]>()
-  expectTypeOf(result.one).toEqualTypeOf<{a: number; b: number}>()
+  expect(xx).toEqual([{a: 1, b: 2}])
+  expect(xx.one).toEqual({a: 1, b: 2})
+  expect(xx.oneFirst).toEqual(1)
+  expect(xx.maybeOneFirst).toEqual(1)
+  expect(xx.many).toEqual([{a: 1, b: 2}])
+  expect(xx.manyFirst).toEqual([1])
+  expectTypeOf(xx).toMatchTypeOf<{a: number; b: number}[]>()
+  expectTypeOf(xx.one).toEqualTypeOf<{a: number; b: number}>()
 
   const Type = z.object({a: z.number(), b: z.number()})
-  const result2 = await sql.type(Type)`select 1 as a, 2 as b`
-  expect(result2).toEqual([{a: 1, b: 2}])
-  expect(result2.one).toEqual({a: 1, b: 2})
-  expect(result2.oneFirst).toEqual(1)
-  expect(result2.maybeOneFirst).toEqual(1)
-  expect(result2.many).toEqual([{a: 1, b: 2}])
-  expect(result2.manyFirst).toEqual([1])
+  const yy = await sql.type(Type)`select 1 as a, 2 as b`
+  expect(yy).toEqual([{a: 1, b: 2}])
+  expect(yy.one).toEqual({a: 1, b: 2})
+  expect(yy.oneFirst).toEqual(1)
+  expect(yy.maybeOneFirst).toEqual(1)
+  expect(yy.many).toEqual([{a: 1, b: 2}])
+  expect(yy.manyFirst).toEqual([1])
 
-  expectTypeOf(result2.manyFirst).toEqualTypeOf<number[]>()
+  expectTypeOf(yy.manyFirst).toEqualTypeOf<number[]>()
 })
 
 test('await sql - clientStorage', async () => {
@@ -485,40 +485,40 @@ test('await sql - clientStorage', async () => {
   )
 
   const results = await pgkitStorage.run({client}, async () => {
-    const one = await sql<{a: number; b: number}>`select 1 as a, 2 as b`
+    const xx = await sql<{a: number; b: number}>`select 1 as a, 2 as b`
 
-    expect(one).toEqual([{a: 1, b: 2}])
-    expect(one.one).toEqual({a: 1, b: 2})
-    expect(one.oneFirst).toEqual(1)
-    expect(one.maybeOneFirst).toEqual(1)
-    expect(one.many).toEqual([{a: 1, b: 2}])
-    expect(one.manyFirst).toEqual([1])
-    expectTypeOf(one).toMatchTypeOf<{a: number; b: number}[]>()
-    expectTypeOf(one.one).toEqualTypeOf<{a: number; b: number}>()
+    expect(xx).toEqual([{a: 1, b: 2}])
+    expect(xx.one).toEqual({a: 1, b: 2})
+    expect(xx.oneFirst).toEqual(1)
+    expect(xx.maybeOneFirst).toEqual(1)
+    expect(xx.many).toEqual([{a: 1, b: 2}])
+    expect(xx.manyFirst).toEqual([1])
+    expectTypeOf(xx).toMatchTypeOf<{a: number; b: number}[]>()
+    expectTypeOf(xx.one).toEqualTypeOf<{a: number; b: number}>()
 
     const Type = z.object({a: z.number(), b: z.number()})
-    const two = await sql.type(Type)`select 1 as a, 2 as b`
-    expect(two).toEqual([{a: 1, b: 2}])
-    expect(two.one).toEqual({a: 1, b: 2})
-    expect(two.oneFirst).toEqual(1)
-    expect(two.maybeOneFirst).toEqual(1)
-    expect(two.many).toEqual([{a: 1, b: 2}])
-    expect(two.manyFirst).toEqual([1])
+    const yy = await sql.type(Type)`select 1 as a, 2 as b`
+    expect(yy).toEqual([{a: 1, b: 2}])
+    expect(yy.one).toEqual({a: 1, b: 2})
+    expect(yy.oneFirst).toEqual(1)
+    expect(yy.maybeOneFirst).toEqual(1)
+    expect(yy.many).toEqual([{a: 1, b: 2}])
+    expect(yy.manyFirst).toEqual([1])
 
-    expectTypeOf(two.manyFirst).toEqualTypeOf<number[]>()
+    expectTypeOf(yy.manyFirst).toEqualTypeOf<number[]>()
 
-    return {one, two}
+    return {xx, yy}
   })
 
   expect(results).toMatchInlineSnapshot(`
     {
-      "one": [
+      "xx": [
         {
           "a": 1,
           "b": 2
         }
       ],
-      "two": [
+      "yy": [
         {
           "a": 1,
           "b": 2

--- a/packages/client/test/api-usage.test.ts
+++ b/packages/client/test/api-usage.test.ts
@@ -496,7 +496,7 @@ test('await sql - clientStorage', async () => {
     expectTypeOf(one).toMatchTypeOf<{a: number; b: number}[]>()
     expectTypeOf(one.one).toEqualTypeOf<{a: number; b: number}>()
 
-    const Type = z.object({one: z.number(), two: z.number()})
+    const Type = z.object({a: z.number(), b: z.number()})
     const two = await sql.type(Type)`select 1 as a, 2 as b`
     expect(two).toEqual([{a: 1, b: 2}])
     expect(two.one).toEqual({a: 1, b: 2})

--- a/packages/client/test/api-usage.test.ts
+++ b/packages/client/test/api-usage.test.ts
@@ -453,7 +453,7 @@ test('createSqlTag + sql.typeAlias', async () => {
 })
 
 test('await sql - createSqlTag', async () => {
-  const sql = createSqlTag({client})
+  const {sql} = client
 
   const result = await sql<{a: number; b: number}>`select 1 as a, 2 as b`
 

--- a/packages/client/test/bugs.test.ts
+++ b/packages/client/test/bugs.test.ts
@@ -79,6 +79,7 @@ test('nested parameterized `sql` tag', async () => {
         returning *
       ",
       "templateArgs": [Function],
+      "then": [Function],
       "token": "sql",
       "values": [
         "four",
@@ -117,6 +118,7 @@ test('nested parameterized `sql.fragment` tag', async () => {
         returning *
       ",
       "templateArgs": [Function],
+      "then": [Function],
       "token": "sql",
       "values": [
         "four",

--- a/packages/client/test/recipes.test.ts
+++ b/packages/client/test/recipes.test.ts
@@ -176,24 +176,24 @@ test('query timeouts', async () => {
   const sleepSeconds = (shortTimeoutMs * 2) / 1000
   await expect(impatient.one(sql`select pg_sleep(${sleepSeconds})`)).rejects.toThrowErrorMatchingInlineSnapshot(
     `
-    [QueryError]: [select_9dcc021]: Executing query failed: Query read timeout
-    {
-      "message": "[select_9dcc021]: Executing query failed: Query read timeout",
-      "query": {
-        "name": "select_9dcc021",
-        "sql": "select pg_sleep($1)",
-        "token": "sql",
-        "values": [
-          0.04
-        ]
-      },
-      "cause": {
-        "name": "Error",
-        "message": "Query read timeout",
-        "query": "select pg_sleep(0.04)"
+      [QueryError]: [select_9dcc021]: Executing query failed: Query read timeout
+      {
+        "message": "[select_9dcc021]: Executing query failed: Query read timeout",
+        "query": {
+          "name": "select_9dcc021",
+          "sql": "select pg_sleep($1)",
+          "token": "sql",
+          "values": [
+            0.04
+          ]
+        },
+        "cause": {
+          "name": "Error",
+          "message": "Query read timeout",
+          "query": "select pg_sleep(0.04)"
+        }
       }
-    }
-  `,
+    `,
   )
   await expect(patient.one(sql`select pg_sleep(${sleepSeconds})`)).resolves.toMatchObject({
     pg_sleep: '',

--- a/packages/migra/package.json
+++ b/packages/migra/package.json
@@ -28,7 +28,7 @@
         "@pgkit/schemainspect": "workspace:^",
         "@trpc/server": "^11.0.1",
         "trpc-cli": "^0.6.0-15",
-        "zod": "^3.23.8"
+        "zod": "^3.25.20"
     },
     "devDependencies": {
         "@types/lodash": "^4.14.202",

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -51,7 +51,7 @@
     "tasuku": "^2.0.1",
     "trpc-cli": "^0.6.0-15",
     "umzug": "^3.7.0",
-    "zod": "^3.23.8",
+    "zod": "^3.25.20",
     "zod-to-json-schema": "^3.23.0",
     "zod-validation-error": "^3.3.0"
   }

--- a/packages/typegen/package.json
+++ b/packages/typegen/package.json
@@ -44,7 +44,7 @@
     "pgsql-ast-parser": "^11.1.0",
     "pluralize": "^8.0.0",
     "trpc-cli": "^0.6.0-15",
-    "zod": "^3.24.4"
+    "zod": "^3.25.20"
   },
   "devDependencies": {
     "@types/glob": "7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,7 +182,7 @@ importers:
         version: 11.0.1(typescript@5.8.2)
       '@uiw/react-codemirror':
         specifier: ^4.21.24
-        version: 4.21.24(@babel/runtime@7.24.4)(@codemirror/autocomplete@6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1))(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.1)(codemirror@6.0.1(@lezer/common@1.2.1))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 4.21.24(@babel/runtime@7.24.4)(@codemirror/autocomplete@6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1))(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.1)(codemirror@6.0.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
         version: 4.2.1(vite@5.1.1(@types/node@20.11.17)(sass@1.71.0))
@@ -253,8 +253,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.11.17)(typescript@5.8.2)))
       zod:
-        specifier: ^3.22.4
-        version: 3.22.4
+        specifier: ^3.25.20
+        version: 3.25.20
     devDependencies:
       '@playwright/test':
         specifier: ^1.42.0
@@ -370,19 +370,19 @@ importers:
         version: https://codeload.github.com/mmkal/np/tar.gz/6a58244afa28fd7d3f8c4dc4b6457c22d74e82de(typescript@5.8.2)
       pg-mem:
         specifier: 3.0.2
-        version: 3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.24.4))
+        version: 3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.25.20))
       quicktype-core:
         specifier: ^23.0.81
         version: 23.0.81(encoding@0.1.13)
       slonik:
         specifier: ^37.2.0
-        version: 37.2.0(zod@3.24.4)
+        version: 37.2.0(zod@3.25.20)
       slonik23:
         specifier: npm:slonik@^23.0.0
         version: slonik@23.9.0
       slonik37:
         specifier: npm:slonik@^37.0.0
-        version: slonik@37.2.0(zod@3.24.4)
+        version: slonik@37.2.0(zod@3.25.20)
       sql-formatter:
         specifier: ^15.2.0
         version: 15.2.0
@@ -405,8 +405,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2(@types/node@20.11.17)(sass@1.71.0)
       zod:
-        specifier: ^3.24.4
-        version: 3.24.4
+        specifier: ^3.25.20
+        version: 3.25.20
 
   packages/formatter:
     dependencies:
@@ -448,8 +448,8 @@ importers:
         specifier: ^0.6.0-15
         version: 0.6.0-15(@inquirer/prompts@5.0.4)(typescript@5.8.2)
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.25.20
+        version: 3.25.20
     devDependencies:
       '@types/lodash':
         specifier: ^4.14.202
@@ -521,14 +521,14 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.25.20
+        version: 3.25.20
       zod-to-json-schema:
         specifier: ^3.23.0
-        version: 3.23.0(zod@3.23.8)
+        version: 3.23.0(zod@3.25.20)
       zod-validation-error:
         specifier: ^3.3.0
-        version: 3.3.0(zod@3.23.8)
+        version: 3.3.0(zod@3.25.20)
     devDependencies:
       '@rebundled/execa':
         specifier: 8.0.2-next.2
@@ -701,8 +701,8 @@ importers:
         specifier: '*'
         version: 5.8.2
       zod:
-        specifier: ^3.24.4
-        version: 3.24.4
+        specifier: ^3.25.20
+        version: 3.25.20
     devDependencies:
       '@types/glob':
         specifier: 7.2.0
@@ -976,8 +976,14 @@ packages:
       '@codemirror/view': ^6.0.0
       '@lezer/common': ^1.0.0
 
+  '@codemirror/autocomplete@6.18.6':
+    resolution: {integrity: sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==}
+
   '@codemirror/commands@6.3.3':
     resolution: {integrity: sha512-dO4hcF0fGT9tu1Pj1D2PvGvxjeGkbC6RGcZw6Qs74TH+Ed1gw98jmUgd2axWvIZEqTeTuFrg1lEB1KV6cK9h1A==}
+
+  '@codemirror/commands@6.8.1':
+    resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
 
   '@codemirror/lang-sql@6.6.0':
     resolution: {integrity: sha512-UKoPjGEistP4yIRH7QmanFAFESTkxI3pib38fECTYwVQ8W6/KCYxvu+uhVLsmPtAlKyE/XaszlMtT4LFye+Y+A==}
@@ -988,17 +994,26 @@ packages:
   '@codemirror/lint@6.5.0':
     resolution: {integrity: sha512-+5YyicIaaAZKU8K43IQi8TBy6mF6giGeWAH7N96Z5LC30Wm5JMjqxOYIE9mxwMG1NbhT2mA3l9hA4uuKUM3E5g==}
 
+  '@codemirror/lint@6.8.5':
+    resolution: {integrity: sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==}
+
   '@codemirror/search@6.5.6':
     resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
 
   '@codemirror/state@6.4.1':
     resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
 
+  '@codemirror/state@6.5.2':
+    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
+
   '@codemirror/theme-one-dark@6.1.2':
     resolution: {integrity: sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==}
 
   '@codemirror/view@6.24.1':
     resolution: {integrity: sha512-sBfP4rniPBRQzNakwuQEqjEuiJDWJyF2kqLLqij4WXRoVwPPJfjx966Eq3F7+OPQxDtMt/Q9MWLoZLWjeveBlg==}
+
+  '@codemirror/view@6.36.8':
+    resolution: {integrity: sha512-yoRo4f+FdnD01fFt4XpfpMCcCAo9QvZOtbrXExn4SqzH32YC6LgzqxfLZw/r6Ge65xyY03mK/UfUqrVw1gFiFg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1451,6 +1466,9 @@ packages:
   '@lezer/highlight@1.2.0':
     resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
 
+  '@lezer/highlight@1.2.1':
+    resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
+
   '@lezer/lr@1.4.0':
     resolution: {integrity: sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==}
 
@@ -1494,6 +1512,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
   '@mdx-js/mdx@2.3.0':
     resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
 
@@ -1517,8 +1538,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2':
     resolution: {integrity: sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
     cpu: [x64]
     os: [darwin]
 
@@ -1527,8 +1558,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
   '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2':
     resolution: {integrity: sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
     cpu: [arm]
     os: [linux]
 
@@ -1537,8 +1578,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2':
     resolution: {integrity: sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
     cpu: [x64]
     os: [win32]
 
@@ -3143,8 +3194,8 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
-  abortcontroller-polyfill@1.7.5:
-    resolution: {integrity: sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==}
+  abortcontroller-polyfill@1.7.8:
+    resolution: {integrity: sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -3253,6 +3304,7 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
+    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.10:
@@ -3399,8 +3451,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  base-x@3.0.9:
-    resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -3452,6 +3504,11 @@ packages:
 
   browserslist@4.23.0:
     resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.24.5:
+    resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3549,6 +3606,9 @@ packages:
 
   caniuse-lite@1.0.30001612:
     resolution: {integrity: sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==}
+
+  caniuse-lite@1.0.30001718:
+    resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4170,6 +4230,10 @@ packages:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
 
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4239,6 +4303,9 @@ packages:
 
   electron-to-chromium@1.4.747:
     resolution: {integrity: sha512-+FnSWZIAvFHbsNVmUxhEqWiaOiPMcfum1GQzlWCg/wLigVtshOsjXHyEFfmt6cFK6+HkS3QOJBv6/3OPumbBfw==}
+
+  electron-to-chromium@1.5.155:
+    resolution: {integrity: sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==}
 
   elegant-spinner@1.0.1:
     resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==}
@@ -4343,6 +4410,10 @@ packages:
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-goat@4.0.0:
@@ -5555,8 +5626,8 @@ packages:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
 
-  jiti@1.21.6:
-    resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
   jiti@2.0.0-beta.3:
@@ -6184,8 +6255,15 @@ packages:
     resolution: {integrity: sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==}
     hasBin: true
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
   msgpackr@1.10.1:
     resolution: {integrity: sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==}
+
+  msgpackr@1.11.4:
+    resolution: {integrity: sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==}
 
   multi-fork@0.0.2:
     resolution: {integrity: sha512-SHWGuze0cZNiH+JGJQFlB1k7kZLGFCvW1Xo5Fcpe86KICkC3aVTJWpjUcmyYcLCB0I6gdzKLCia/bTIw2ggl8A==}
@@ -6329,8 +6407,15 @@ packages:
     resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
     hasBin: true
 
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
   node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
   non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
@@ -6786,6 +6871,9 @@ packages:
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -7388,6 +7476,11 @@ packages:
 
   semver@7.6.0:
     resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -8258,6 +8351,12 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   update-notifier@7.0.0:
     resolution: {integrity: sha512-Hv25Bh+eAbOLlsjJreVPOs4vd51rrtCrmhyOJtbpAojro34jS4KQaEp4/EvlHJX7jSO42VvEFpkastVyXyIsdQ==}
     engines: {node: '>=18'}
@@ -8574,17 +8673,8 @@ packages:
     peerDependencies:
       zod: ^3.18.0
 
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
-
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+  zod@3.25.20:
+    resolution: {integrity: sha512-z03fqpTMDF1G02VLKUMt6vyACE7rNWkh3gpXVHgPTw28NPtDFRGvcpTtPwn2kMKtQ0idtYJUTxchytmnqYswcw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8815,11 +8905,25 @@ snapshots:
       '@codemirror/view': 6.24.1
       '@lezer/common': 1.2.1
 
+  '@codemirror/autocomplete@6.18.6':
+    dependencies:
+      '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.8
+      '@lezer/common': 1.2.1
+
   '@codemirror/commands@6.3.3':
     dependencies:
       '@codemirror/language': 6.10.1
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.24.1
+      '@lezer/common': 1.2.1
+
+  '@codemirror/commands@6.8.1':
+    dependencies:
+      '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.8
       '@lezer/common': 1.2.1
 
   '@codemirror/lang-sql@6.6.0(@codemirror/view@6.24.1)':
@@ -8848,24 +8952,40 @@ snapshots:
       '@codemirror/view': 6.24.1
       crelt: 1.0.6
 
+  '@codemirror/lint@6.8.5':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.8
+      crelt: 1.0.6
+
   '@codemirror/search@6.5.6':
     dependencies:
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.24.1
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.8
       crelt: 1.0.6
 
   '@codemirror/state@6.4.1': {}
 
+  '@codemirror/state@6.5.2':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
   '@codemirror/theme-one-dark@6.1.2':
     dependencies:
       '@codemirror/language': 6.10.1
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.24.1
-      '@lezer/highlight': 1.2.0
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.8
+      '@lezer/highlight': 1.2.1
 
   '@codemirror/view@6.24.1':
     dependencies:
       '@codemirror/state': 6.4.1
+      style-mod: 4.1.2
+      w3c-keyname: 2.2.8
+
+  '@codemirror/view@6.36.8':
+    dependencies:
+      '@codemirror/state': 6.5.2
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
 
@@ -9231,6 +9351,10 @@ snapshots:
     dependencies:
       '@lezer/common': 1.2.1
 
+  '@lezer/highlight@1.2.1':
+    dependencies:
+      '@lezer/common': 1.2.1
+
   '@lezer/lr@1.4.0':
     dependencies:
       '@lezer/common': 1.2.1
@@ -9260,6 +9384,8 @@ snapshots:
 
   '@lmdb/lmdb-win32-x64@2.8.5':
     optional: true
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@2.3.0':
     dependencies:
@@ -9307,19 +9433,37 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2':
     optional: true
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
   '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2':
     optional: true
 
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
   '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2':
     optional: true
 
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.16':
@@ -9443,16 +9587,16 @@ snapshots:
       '@parcel/types': 2.11.0(@parcel/core@2.11.0)
       '@parcel/utils': 2.11.0
       '@parcel/workers': 2.11.0(@parcel/core@2.11.0)
-      abortcontroller-polyfill: 1.7.5
-      base-x: 3.0.9
-      browserslist: 4.23.0
+      abortcontroller-polyfill: 1.7.8
+      base-x: 3.0.11
+      browserslist: 4.24.5
       clone: 2.1.2
       dotenv: 7.0.0
       dotenv-expand: 5.1.0
       json5: 2.2.3
-      msgpackr: 1.10.1
+      msgpackr: 1.11.4
       nullthrows: 1.1.1
-      semver: 7.6.0
+      semver: 7.7.2
 
   '@parcel/diagnostic@2.11.0':
     dependencies:
@@ -11360,7 +11504,7 @@ snapshots:
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.24.1
 
-  '@uiw/react-codemirror@4.21.24(@babel/runtime@7.24.4)(@codemirror/autocomplete@6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1))(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.1)(codemirror@6.0.1(@lezer/common@1.2.1))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@uiw/react-codemirror@4.21.24(@babel/runtime@7.24.4)(@codemirror/autocomplete@6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1))(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.24.1)(codemirror@6.0.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
       '@codemirror/commands': 6.3.3
@@ -11368,7 +11512,7 @@ snapshots:
       '@codemirror/theme-one-dark': 6.1.2
       '@codemirror/view': 6.24.1
       '@uiw/codemirror-extensions-basic-setup': 4.21.24(@codemirror/autocomplete@6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1))(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)
-      codemirror: 6.0.1(@lezer/common@1.2.1)
+      codemirror: 6.0.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -11425,7 +11569,7 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  abortcontroller-polyfill@1.7.5: {}
+  abortcontroller-polyfill@1.7.8: {}
 
   accepts@1.3.8:
     dependencies:
@@ -11682,7 +11826,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base-x@3.0.9:
+  base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
 
@@ -11761,6 +11905,13 @@ snapshots:
       electron-to-chromium: 1.4.747
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
+
+  browserslist@4.24.5:
+    dependencies:
+      caniuse-lite: 1.0.30001718
+      electron-to-chromium: 1.5.155
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.3(browserslist@4.24.5)
 
   buffer-from@1.1.2: {}
 
@@ -11852,6 +12003,8 @@ snapshots:
   camelcase@7.0.1: {}
 
   caniuse-lite@1.0.30001612: {}
+
+  caniuse-lite@1.0.30001718: {}
 
   ccount@2.0.1: {}
 
@@ -12012,17 +12165,15 @@ snapshots:
 
   code-point-at@1.1.0: {}
 
-  codemirror@6.0.1(@lezer/common@1.2.1):
+  codemirror@6.0.1:
     dependencies:
-      '@codemirror/autocomplete': 6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1)
-      '@codemirror/commands': 6.3.3
+      '@codemirror/autocomplete': 6.18.6
+      '@codemirror/commands': 6.8.1
       '@codemirror/language': 6.10.1
-      '@codemirror/lint': 6.5.0
+      '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.5.6
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.24.1
-    transitivePeerDependencies:
-      - '@lezer/common'
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.8
 
   collection-utils@1.0.1: {}
 
@@ -12466,6 +12617,9 @@ snapshots:
 
   detect-libc@2.0.2: {}
 
+  detect-libc@2.0.4:
+    optional: true
+
   detect-newline@4.0.1: {}
 
   detect-node-es@1.1.0: {}
@@ -12517,6 +12671,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.4.747: {}
+
+  electron-to-chromium@1.5.155: {}
 
   elegant-spinner@1.0.1: {}
 
@@ -12728,6 +12884,8 @@ snapshots:
       '@esbuild/win32-x64': 0.23.1
 
   escalade@3.1.2: {}
+
+  escalade@3.2.0: {}
 
   escape-goat@4.0.0: {}
 
@@ -14204,7 +14362,7 @@ snapshots:
       debug: 4.3.7
       esbuild: 0.23.1
       jiti: 2.0.0-beta.3
-      jiti-v1: jiti@1.21.6
+      jiti-v1: jiti@1.21.7
       pathe: 1.1.2
       tsx: 4.19.0
     transitivePeerDependencies:
@@ -14648,7 +14806,7 @@ snapshots:
 
   jiti@1.21.0: {}
 
-  jiti@1.21.6: {}
+  jiti@1.21.7: {}
 
   jiti@2.0.0-beta.3: {}
 
@@ -15569,9 +15727,25 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.2
     optional: true
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
   msgpackr@1.10.1:
     optionalDependencies:
       msgpackr-extract: 3.0.2
+
+  msgpackr@1.11.4:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
 
   multi-fork@0.0.2: {}
 
@@ -15694,7 +15868,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.1.0
-      zod: 3.24.2
+      zod: 3.25.20
 
   nextra@2.13.4(next@14.2.4(@playwright/test@1.42.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -15726,7 +15900,7 @@ snapshots:
       title: 3.5.3
       unist-util-remove: 4.0.0
       unist-util-visit: 5.0.0
-      zod: 3.24.2
+      zod: 3.25.20
     transitivePeerDependencies:
       - supports-color
 
@@ -15755,7 +15929,14 @@ snapshots:
     dependencies:
       detect-libc: 2.0.2
 
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.0.4
+    optional: true
+
   node-releases@2.0.14: {}
+
+  node-releases@2.0.19: {}
 
   non-layered-tidy-tree-layout@2.0.2: {}
 
@@ -16162,7 +16343,7 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-mem@3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.24.4)):
+  pg-mem@3.0.2(pg-promise@11.5.4)(slonik@37.2.0(zod@3.25.20)):
     dependencies:
       functional-red-black-tree: 1.0.1
       immutable: 4.3.5
@@ -16173,7 +16354,7 @@ snapshots:
       pgsql-ast-parser: 12.0.1
     optionalDependencies:
       pg-promise: 11.5.4
-      slonik: 37.2.0(zod@3.24.4)
+      slonik: 37.2.0(zod@3.25.20)
 
   pg-minify@1.6.3: {}
 
@@ -16264,6 +16445,8 @@ snapshots:
   picocolors@1.0.0: {}
 
   picocolors@1.0.1: {}
+
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
@@ -16928,6 +17111,8 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  semver@7.7.2: {}
+
   send@0.18.0:
     dependencies:
       debug: 2.6.9
@@ -17000,7 +17185,7 @@ snapshots:
       recast: 0.23.6
       ts-morph: 18.0.0
       tsconfig-paths: 4.2.0
-      zod: 3.24.4
+      zod: 3.25.20
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17085,7 +17270,7 @@ snapshots:
     transitivePeerDependencies:
       - pg-native
 
-  slonik@37.2.0(zod@3.24.4):
+  slonik@37.2.0(zod@3.25.20):
     dependencies:
       '@types/pg': 8.11.0
       es6-error: 4.1.1
@@ -17100,7 +17285,7 @@ snapshots:
       roarr: 7.21.0
       safe-stable-stringify: 2.4.3
       serialize-error: 8.1.0
-      zod: 3.24.4
+      zod: 3.25.20
     transitivePeerDependencies:
       - pg-native
 
@@ -17528,9 +17713,9 @@ snapshots:
       '@types/omelette': 0.4.5
       commander: 13.1.0
       picocolors: 1.0.1
-      zod: 3.24.4
-      zod-to-json-schema: 3.23.0(zod@3.24.4)
-      zod-validation-error: 3.3.0(zod@3.24.4)
+      zod: 3.25.20
+      zod-to-json-schema: 3.23.0(zod@3.25.20)
+      zod-validation-error: 3.3.0(zod@3.25.20)
     optionalDependencies:
       '@inquirer/prompts': 5.0.4
     transitivePeerDependencies:
@@ -17950,6 +18135,12 @@ snapshots:
       browserslist: 4.23.0
       escalade: 3.1.2
       picocolors: 1.0.1
+
+  update-browserslist-db@1.1.3(browserslist@4.24.5):
+    dependencies:
+      browserslist: 4.24.5
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   update-notifier@7.0.0:
     dependencies:
@@ -18484,7 +18675,7 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
-      strip-ansi: 6.0.0
+      strip-ansi: 6.0.1
 
   wrap-ansi@8.1.0:
     dependencies:
@@ -18529,28 +18720,14 @@ snapshots:
     dependencies:
       '@types/yoga-layout': 1.9.2
 
-  zod-to-json-schema@3.23.0(zod@3.23.8):
+  zod-to-json-schema@3.23.0(zod@3.25.20):
     dependencies:
-      zod: 3.23.8
+      zod: 3.25.20
 
-  zod-to-json-schema@3.23.0(zod@3.24.4):
+  zod-validation-error@3.3.0(zod@3.25.20):
     dependencies:
-      zod: 3.24.4
+      zod: 3.25.20
 
-  zod-validation-error@3.3.0(zod@3.23.8):
-    dependencies:
-      zod: 3.23.8
-
-  zod-validation-error@3.3.0(zod@3.24.4):
-    dependencies:
-      zod: 3.24.4
-
-  zod@3.22.4: {}
-
-  zod@3.23.8: {}
-
-  zod@3.24.2: {}
-
-  zod@3.24.4: {}
+  zod@3.25.20: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Support awaiting the sql function itself like the cool kids at bun and `postgres` are doing

```ts
import {createClient} from '@pgkit/client'

const {sql} = createClient('postgresql://')

const profiles = await sql`select * from profile where email = ${getEmail()}`
```