### PR TITLE
chore: sqlFnInner readability

### DIFF
--- a/packages/client/src/sql.ts
+++ b/packages/client/src/sql.ts
@@ -127,19 +127,19 @@ const sqlFnInner = (
       }
 
       case 'join': {
-        param.args[0].forEach((value, j, {length}) => {
+        const [members, glue] = param.args
+        members.forEach((value, j, {length}) => {
           if (value && typeof value === 'object' && value?.token === 'sql') {
             const innerArgs = value.templateArgs() as Parameters<SQLTagFunction>
             const innerResult = sqlFnInner({priorValues: values.length + priorValues}, ...innerArgs)
             segments.push(...innerResult.segments())
             values.push(...innerResult.values)
-            if (j < length - 1) segments.push(param.args[1].sql)
-            return
+          } else {
+            values.push(value)
+            segments.push(getValuePlaceholder())
           }
 
-          values.push(value)
-          segments.push(getValuePlaceholder())
-          if (j < length - 1) segments.push(param.args[1].sql)
+          if (j < length - 1) segments.push(glue.sql)
         })
         break
       }

--- a/packages/client/test/bugs.test.ts
+++ b/packages/client/test/bugs.test.ts
@@ -167,6 +167,33 @@ test('join param', async () => {
     }
   `)
   await client.query(query)
-  const result = await client.one(sql`select * from edge_cases_test where id = ${11}`)
-  expect(result).toEqual({id: 11, name: 'eleven'})
+  const result = await client.any(sql`select * from edge_cases_test where id = ${11}`)
+  expect(result).toEqual([{id: 11, name: 'eleven'}])
+})
+test('mixed join param', async () => {
+  const parts = [sql`${1} as one`, 2, sql`3 as three`]
+
+  const query = sql`
+    select ${sql.join(parts, sql`, `)}
+  `
+
+  expect(query).toMatchInlineSnapshot(`
+    {
+      "name": "select_16400f2",
+      "parse": [Function],
+      "segments": [Function],
+      "sql": "
+        select $1 as one, $2, 3 as three
+      ",
+      "templateArgs": [Function],
+      "then": [Function],
+      "token": "sql",
+      "values": [
+        1,
+        2,
+      ],
+    }
+  `)
+  const result = await client.any(query)
+  expect(result).toEqual([{one: 1, '?column?': 2, three: 3}])
 })


### PR DESCRIPTION
Whenever I go to this switch statement I find it hard to remember what's going on with all the `param.args[0]` and `param.args[1]` stuff. Each token type has a pretty different form, so this gives the `param.args` tuple members variables with names.