### PR TITLE
fix: remove undefined dependencies

### DIFF
--- a/packages/schemainspect/src/pg/obj.ts
+++ b/packages/schemainspect/src/pg/obj.ts
@@ -1429,7 +1429,7 @@ export class PostgreSQL extends DBInspector {
       att: 'dependent_on' | 'dependents',
     ): string[] => {
       const related = item[att].map((child: string) => this.get_dependency_by_signature(child))
-      return [item.signature, ...related.flatMap(d => get_related_for_item(d, att))]
+      return [item.signature, ...related.filter(d => d).flatMap(d => get_related_for_item(d, att))]
     }
 
     for (const [k, x] of Object.entries(this.selectables)) {


### PR DESCRIPTION
The function `get_dependency_by_signature` may return undefined if none of the things match the given signature.

Filter out those undefined dependencies so that migra doesn't crash out completely.

Steps to reproduce
---

The simplest repro is to create the following view on supabase.

```sql
CREATE OR REPLACE VIEW "public"."users" AS
 SELECT * FROM "auth"."users" "o"
  WHERE ("o"."id" = "auth"."uid"());
```

Then run migra on the same database.

```ts
import { createClient } from "@pgkit/client";
import { Migration } from "@pgkit/migra";

const dbURL = "postgres://..."
const clientBase = createClient(dbURL);
const clientHead = createClient(dbURL);

const m = await Migration.create(clientBase, clientHead, {});
m.add_all_changes(true);
console.log(m.sql);
```
