### PR TITLE
Fix priorValues calculation in sql.ts

### DIFF
--- a/packages/client/src/sql.ts
+++ b/packages/client/src/sql.ts
@@ -173,7 +173,7 @@ const sqlFnInner = (
 
       case 'fragment': {
         const innerArgs = param.args as Parameters<SQLTagFunction>
-        const innerResult = sqlFnInner({priorValues: values.length}, ...innerArgs)
+        const innerResult = sqlFnInner({priorValues: values.length + priorValues}, ...innerArgs)
         segments.push(...innerResult.segments())
         values.push(...innerResult.values)
         break
@@ -181,7 +181,7 @@ const sqlFnInner = (
 
       case 'sql': {
         const innerArgs = param.templateArgs() as Parameters<SQLTagFunction>
-        const innerResult = sqlFnInner({priorValues: values.length}, ...innerArgs)
+        const innerResult = sqlFnInner({priorValues: values.length + priorValues}, ...innerArgs)
         segments.push(...innerResult.segments())
         values.push(...innerResult.values)
         break


### PR DESCRIPTION
`sql` and `fragment` token types are not passing their `priorValues`, causing nested `sql` fragments to using incorrect placeholder values.